### PR TITLE
changed this --  sys.path.insert(0,'libs')  and other line

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import webapp2
 import urllib2
 import urlparse
 import sys
-sys.path.insert(0,'libs')
+sys.path.insert(1,'libs')
 from bs4 import BeautifulSoup as bsp
 import os
 import jinja2
@@ -51,7 +51,7 @@ def Quora(self,r_url):
     for i in range(count):
         if answers[i].find('div',class_='answer_content'):
             self.response.write(answers[i].find('div',class_='answer_content').text)
-            self.response.write('-----------------------------------------------------------------')
+            self.response.write('--'*30)
     
     
 


### PR DESCRIPTION
i) It should be sys.path.insert(1,'libs') 
As initialized upon program startup, the first item of this list, path[0], is the directory containing the script that was used to invoke the Python interpreter. If the script directory is not available (e.g. if the interpreter is invoked interactively or if the script is read from standard input), path[0] is the empty string 
  took this from here:--    https://docs.python.org/2/library/sys.html#sys.path

also this is said in this below link
http://stackoverflow.com/questions/10095037/why-use-sys-path-appendpath-instead-of-sys-path-insert1-path#answer-10097543

ii) also it would be nice if  '--'*25 is used rather than  '----------------------------'

  also I am interested in contributing to your code in near future :)
